### PR TITLE
feat: 유저 문제 풀이 스냅샷 수집 / 변경 감지 구현

### DIFF
--- a/.idea/modules/batch.main.iml
+++ b/.idea/modules/batch.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../slackjudge/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../slackjudge/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/slackjudge/build.gradle
+++ b/slackjudge/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	//webclient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/slackjudge/build.gradle
+++ b/slackjudge/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql' // PostgreSQL 모듈
     testImplementation "org.testcontainers:junit-jupiter" // JUnit 5 연동
 	testImplementation 'org.testcontainers:jdbc'
+	testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.0'
 }
 
 tasks.named('test') {

--- a/slackjudge/src/main/java/store/slackjudge/batch/common/CalculateSnapShotDate.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/common/CalculateSnapShotDate.java
@@ -1,0 +1,59 @@
+package store.slackjudge.batch.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 집계 날짜 계산 util 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class CalculateSnapShotDate {
+    private final Clock clock;
+
+    /*==========================
+    *
+    *CalculateSnapShotDate
+    *
+    * @return 현재 시간
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    public LocalDateTime now(){
+        return LocalDateTime.now(clock);
+    }
+
+    /*==========================
+    *
+    *CalculateSnapShotDate
+    *
+    * @return 현재 시간:hour
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    public LocalDateTime currentHour(){
+        return now().truncatedTo(ChronoUnit.HOURS);
+    }
+
+    /*==========================
+    *
+    *CalculateSnapShotDate
+    * @return 현재 시간: (hour-1)
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    public LocalDateTime snapshotDate(){
+        return currentHour().minusHours(1);
+    }
+
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/config/TimeConfig.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package store.slackjudge.batch.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock clock(){
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-@Embeddable
+@AllArgsConstructor
+@RequiredArgsConstructor
 public class SnapShotId implements Serializable {
     private String bojId;
     private LocalDateTime snapShotAt;

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
@@ -10,12 +10,15 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @RequiredArgsConstructor
 public class SnapShotId implements Serializable {
     private String bojId;
     private LocalDateTime snapShotAt;
 
+    public static SnapShotId of(String bojId,LocalDateTime snapShotAt){
+        return new SnapShotId(bojId,snapShotAt);
+    }
     @Override
     public boolean equals(Object o){
         if(this==o) return true;

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
@@ -1,10 +1,7 @@
 package store.slackjudge.batch.infra.mongo.document;
 
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -12,6 +9,7 @@ import java.util.Objects;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @RequiredArgsConstructor
+@Getter
 public class SnapShotId implements Serializable {
     private String bojId;
     private LocalDateTime snapShotAt;

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/SnapShotId.java
@@ -1,0 +1,33 @@
+package store.slackjudge.batch.infra.mongo.document;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Embeddable
+public class SnapShotId implements Serializable {
+    private String bojId;
+    private LocalDateTime snapShotAt;
+
+    @Override
+    public boolean equals(Object o){
+        if(this==o) return true;
+        if (o==null || this.getClass()!=o.getClass()) return false;
+
+        SnapShotId snapShotId=(SnapShotId) o;
+
+        return Objects.equals(snapShotId.bojId,this.bojId)
+               && Objects.equals(snapShotId.snapShotAt,this.snapShotAt);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(bojId,snapShotAt);
+    }
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
@@ -1,0 +1,30 @@
+package store.slackjudge.batch.infra.mongo.document;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Document(collection = "snapshot")
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class UserSolvedSnapShotDocument {
+    //(백준 아이디, 배치 동작 시간) 복합 키
+    @EmbeddedId
+    private SnapShotId id;
+
+    private Set<Integer> solvedProblemIds;
+
+    private Integer solvedCount;
+
+    private Integer tier;
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
@@ -31,6 +31,9 @@ public class UserSolvedSnapShotDocument {
 
     private Integer tier;
 
+    @Builder.Default
+    private Integer rating=0;
+
     @NotNull
     @Field(name = "user_id")
     private Long userId;

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
@@ -12,14 +12,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.util.List;
 import java.util.Set;
 
-@Entity
 @Document(collection = "snapshot")
 @Getter
 @RequiredArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class UserSolvedSnapShotDocument {
     //(백준 아이디, 배치 동작 시간) 복합 키
-    @EmbeddedId
+    @Id
     private SnapShotId id;
 
     private Set<Integer> solvedProblemIds;
@@ -27,4 +26,6 @@ public class UserSolvedSnapShotDocument {
     private Integer solvedCount;
 
     private Integer tier;
+
+    private Long userId;
 }

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/document/UserSolvedSnapShotDocument.java
@@ -3,15 +3,16 @@ package store.slackjudge.batch.infra.mongo.document;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.hibernate.annotations.Filter;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.List;
 import java.util.Set;
 
+@Builder
 @Document(collection = "snapshot")
 @Getter
 @RequiredArgsConstructor
@@ -21,11 +22,16 @@ public class UserSolvedSnapShotDocument {
     @Id
     private SnapShotId id;
 
+    @Field(name = "problems_ids")
     private Set<Integer> solvedProblemIds;
 
-    private Integer solvedCount;
+    @Builder.Default
+    @Field(name = "solved_count")
+    private Integer solvedCount=0;
 
     private Integer tier;
 
+    @NotNull
+    @Field(name = "user_id")
     private Long userId;
 }

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/dto/SaveSnapshot.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/dto/SaveSnapshot.java
@@ -14,6 +14,7 @@ public record SaveSnapshot(
     Set<Integer> solvedProblemIds,
     Integer solvedCount,
     Integer tier,
-    Long userId
+    Long userId,
+    Integer rating
 ) {
 }

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/dto/SaveSnapshot.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/dto/SaveSnapshot.java
@@ -1,0 +1,19 @@
+package store.slackjudge.batch.infra.mongo.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+/**
+ * Document 저장용 DTO
+ */
+public record SaveSnapshot(
+    String bojId,
+    LocalDateTime snapShotAt,
+    Set<Integer> solvedProblemIds,
+    Integer solvedCount,
+    Integer tier,
+    Long userId
+) {
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepository.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepository.java
@@ -5,9 +5,10 @@ import org.springframework.stereotype.Repository;
 import store.slackjudge.batch.infra.mongo.document.SnapShotId;
 import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface UserSolvedSnapShotRepository extends MongoRepository<UserSolvedSnapShotDocument, SnapShotId> {
-    Optional<UserSolvedSnapShotDocument> findById(SnapShotId id);
+    Optional<UserSolvedSnapShotDocument> findByIdBojIdAndIdSnapShotAt(String bojId, LocalDateTime snapShotAt);
 }

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepository.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepository.java
@@ -1,0 +1,13 @@
+package store.slackjudge.batch.infra.mongo.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import store.slackjudge.batch.infra.mongo.document.SnapShotId;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+
+import java.util.Optional;
+
+@Repository
+public interface UserSolvedSnapShotRepository extends MongoRepository<UserSolvedSnapShotDocument, SnapShotId> {
+    Optional<UserSolvedSnapShotDocument> findById(SnapShotId id);
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotService.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotService.java
@@ -1,0 +1,60 @@
+package store.slackjudge.batch.infra.mongo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.slackjudge.batch.infra.mongo.document.SnapShotId;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.mongo.dto.SaveSnapshot;
+import store.slackjudge.batch.infra.mongo.repository.UserSolvedSnapShotRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSnapShotService {
+    private final UserSolvedSnapShotRepository repository;
+
+    /*==========================
+    *
+    *UserSnapShotService
+    * 1시간 전 스냅 샷 조회 메서드
+    * @parm bojId:백준 아이디 / previousTime:1시간 전 시간
+    * @return 유저+문제 풀이 정보 도큐먼트
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    @Transactional(readOnly = true)
+    public Optional<UserSolvedSnapShotDocument> findPreviousSnapshot(String bojId, LocalDateTime previousTime){
+        return repository.findByIdBojIdAndIdSnapShotAt(bojId,previousTime);
+    }
+
+    /*==========================
+    *
+    *UserSnapShotService
+    * Snapshot Document 객체를 저장하는 메서드
+    * @parm SaveSnapshot:데이터 전달을 위한 DTO
+    * @return 저장된 snapshot document
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    @Transactional
+    public UserSolvedSnapShotDocument saveSnapshot(SaveSnapshot snapshot){
+        SnapShotId id=SnapShotId.of(snapshot.bojId(),snapshot.snapShotAt());
+        UserSolvedSnapShotDocument document=UserSolvedSnapShotDocument.builder()
+                .id(id)
+                .solvedCount(snapshot.solvedCount())
+                .solvedProblemIds(snapshot.solvedProblemIds())
+                .tier(snapshot.tier())
+                .userId(snapshot.userId())
+                .build();
+
+        //객체 저장
+        return repository.save(document);
+    }
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotService.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotService.java
@@ -11,6 +11,9 @@ import store.slackjudge.batch.infra.mongo.repository.UserSolvedSnapShotRepositor
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+/**
+ * user의 스냅샷 저장 / 조회 클래스
+ */
 @Service
 @RequiredArgsConstructor
 public class UserSnapShotService {

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/DetectionContext.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/DetectionContext.java
@@ -1,0 +1,13 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+
+import java.time.LocalDateTime;
+
+public record DetectionContext <T>(
+        T current,
+        UserSolvedSnapShotDocument previous,
+        LocalDateTime snapshotAt,
+        Long userId,
+        String bojId
+){}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetector.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetector.java
@@ -21,11 +21,33 @@ import java.util.stream.Collectors;
 public class ProblemChangeDetector implements SnapshotDetectStrategy<ProblemSearchResponse> {
     private final ProblemJdbcRepository repository;
 
+    /*==========================
+    *
+    *ProblemChangeDetector
+    * solved.ac API 통신으로 최신 유저가 푼 문제 정보와 1시간 전 유저가 푼 문제 정보 비교 메서드
+    * @parm context:변경감지 객체
+    * @return true:변경 o / false:변경 x
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
     @Override
     public boolean detect(DetectionContext<ProblemSearchResponse> context) {
         return context.previous().getSolvedCount() != context.current().count();
     }
 
+    /*==========================
+    *
+    *ProblemChangeDetector
+    * RDB에 유저의 새로 푼 문제 업데이트
+    * @parm context:변경감지 객체
+    * @return void
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
     @Override
     public void update(DetectionContext<ProblemSearchResponse> context) {
         //스냅샷에 존재하는 유저의 모든 문제 번호

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetector.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetector.java
@@ -1,0 +1,50 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.solvedac.dto.ProblemInfoResponse;
+import store.slackjudge.batch.infra.solvedac.dto.ProblemSearchResponse;
+import store.slackjudge.batch.repository.ProblemJdbcRepository;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/* [ 사용자가 푼 문제 감지 전략 ]
+ * 변경 감지 전략 구현체
+ */
+@Component
+@RequiredArgsConstructor
+public class ProblemChangeDetector implements SnapshotDetectStrategy<ProblemSearchResponse> {
+    private final ProblemJdbcRepository repository;
+
+    @Override
+    public boolean detect(DetectionContext<ProblemSearchResponse> context) {
+        return context.previous().getSolvedCount() != context.current().count();
+    }
+
+    @Override
+    public void update(DetectionContext<ProblemSearchResponse> context) {
+        //스냅샷에 존재하는 유저의 모든 문제 번호
+        Set<Integer> previousProblemIds = context.previous().getSolvedProblemIds();
+
+        //새로 조회한 유저의 모든 문제 번호
+        Set<Integer> currentProblemIds =
+                context.current()
+                        .items()
+                        .stream()
+                        .map(ProblemInfoResponse::problemId)
+                        .collect(Collectors.toSet());
+
+        //새로 푼 문제 업데이트
+        currentProblemIds.stream()
+                //사용자가 이전에 푼 문제 set에 포함되지 않은 경우 -> 새로 푼 문제
+                .filter(p -> !previousProblemIds.contains(p))
+                .forEach(pid -> {
+                    repository.updateProblemSolved(context.snapshotAt(), context.userId(), pid);
+                });
+    }
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/SnapshotDetectStrategy.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/SnapshotDetectStrategy.java
@@ -1,0 +1,11 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+
+/**
+ * strategy pattern 적용
+ */
+public interface SnapshotDetectStrategy<T> {
+    boolean detect(DetectionContext<T> context);
+    void update(DetectionContext<T> context);
+}

--- a/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/TierChangeDetector.java
+++ b/slackjudge/src/main/java/store/slackjudge/batch/infra/mongo/service/detector/TierChangeDetector.java
@@ -1,0 +1,48 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.solvedac.dto.UserInfoResponse;
+import store.slackjudge.batch.repository.UserJdbcRepository;
+
+/* [ 사용자 티어 감지 전략 ]
+ * 변경 감지 전략 구현체
+ */
+@Component
+@RequiredArgsConstructor
+public class TierChangeDetector implements SnapshotDetectStrategy<UserInfoResponse>{
+    private final UserJdbcRepository userRepository;
+
+    /*==========================
+    *
+    *TierChangeDetector
+    * solved.ac API 통신으로 최신 유저 티어 정보와 1시간 전 유저 티어 비교 메서드
+    * @parm context:변경감지 객체
+    * @return true:변경 o / false:변경 x
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    @Override
+    public boolean detect(DetectionContext<UserInfoResponse> context) {
+        return context.current().tier()!=context.previous().getTier();
+    }
+
+    /*==========================
+    *
+    *TierChangeDetector
+    * RDB에 유저의 새 티어정보 업데이트
+    * @parm context:변경감지 객체
+    * @return void
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 12. 10.
+    *
+    ==========================**/
+    @Override
+    public void update(DetectionContext<UserInfoResponse> context) {
+        userRepository.updateUsersTier(context.current().handle(),context.current().tier());
+    }
+}

--- a/slackjudge/src/main/resources/application.yml
+++ b/slackjudge/src/main/resources/application.yml
@@ -20,6 +20,7 @@ solved:
   api:
     user-info: https://solved.ac/api/v3/search/user
     problem-info: https://solved.ac/api/v3/search/problem
+
 ---
 
 spring:

--- a/slackjudge/src/test/java/store/slackjudge/batch/common/CalculateSnapShotDateTest.java
+++ b/slackjudge/src/test/java/store/slackjudge/batch/common/CalculateSnapShotDateTest.java
@@ -1,0 +1,58 @@
+package store.slackjudge.batch.common;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CalculateSnapShotDateTest {
+    private final LocalDateTime fixedTime=LocalDateTime.of(2025,12,12,12,12,12,12);;
+    private final Clock fixedClock=Clock.fixed(fixedTime.toInstant(ZoneOffset.UTC),ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("clock 추상 객체를 이용해 현재 시간 LocalDateTime 생성")
+    void createNow(){
+        //given
+        CalculateSnapShotDate calculator=new CalculateSnapShotDate(fixedClock);
+
+        //when
+        LocalDateTime result=calculator.now();
+
+        //then
+        assertThat(result).isEqualTo(fixedTime);
+    }
+
+    @Test
+    @DisplayName("clock 추상 객체 이용하여 현재 시간 기준 hour 아래값 절삭")
+    void currentHour(){
+        //given
+        CalculateSnapShotDate calculator=new CalculateSnapShotDate(fixedClock);
+
+        //when
+        LocalDateTime result=calculator.currentHour();
+
+        //then
+        assertThat(result).isEqualTo(LocalDateTime.of(2025,12,12,12,0,0,0));
+    }
+
+    @Test
+    @DisplayName("clock 추상 객체 이용하여 현재 시간 기준 hour 아래값 절삭 후 -1 hour")
+    void snapshotDate(){
+        //when
+        CalculateSnapShotDate calculator=new CalculateSnapShotDate(fixedClock);
+
+        //when
+        LocalDateTime result=calculator.snapshotDate();
+
+        //then
+        assertThat(result).isEqualTo(LocalDateTime.of(2025,12,12,11,0,0,0));
+
+    }
+}

--- a/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepositoryTest.java
+++ b/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/repository/UserSolvedSnapShotRepositoryTest.java
@@ -1,0 +1,75 @@
+package store.slackjudge.batch.infra.mongo.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import store.slackjudge.batch.SlackjudgeApplication;
+import store.slackjudge.batch.infra.mongo.document.SnapShotId;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestPropertySource(locations = "/application.yml")
+@ContextConfiguration(classes = SlackjudgeApplication.class)
+@DataMongoTest
+@ExtendWith(SpringExtension.class)
+@DirtiesContext
+class UserSolvedSnapShotRepositoryTest {
+    @Autowired
+    private UserSolvedSnapShotRepository repository;
+
+    @Test
+    @DisplayName("백준Id와 집계날짜로 document를 조회")
+    void findByBojIdAndIdSnapshotAt(){
+        //given
+        LocalDateTime now=LocalDateTime.now().truncatedTo(ChronoUnit.HOURS);
+        String bojId="test";
+        Long userId=123L;
+        int tier=23;
+        int solvedCount=33;
+
+        repository.save(makeDummyDocument(
+                bojId,userId,tier,solvedCount,now
+        ));
+
+        //when
+        UserSolvedSnapShotDocument result=repository.findByIdBojIdAndIdSnapShotAt(bojId,now).get();
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getId().getBojId()).isEqualTo(bojId);
+        assertThat(result.getId().getSnapShotAt()).isEqualTo(now);
+        assertThat(result.getRating()).isEqualTo(100);
+        assertThat(result.getSolvedCount()).isEqualTo(solvedCount);
+        assertThat(result.getTier()).isEqualTo(tier);
+        assertThat(result.getUserId()).isEqualTo(userId);
+    }
+
+
+    private static UserSolvedSnapShotDocument makeDummyDocument(String bojId, Long userId, int tier, int solvedCount, LocalDateTime snapshotAt){
+        SnapShotId id=SnapShotId.of(bojId,snapshotAt);
+
+        return UserSolvedSnapShotDocument.builder()
+                .id(id)
+                .rating(100)
+                .solvedCount(solvedCount)
+                .solvedProblemIds(new HashSet<>())
+                .tier(tier)
+                .userId(userId)
+                .build();
+    }
+}

--- a/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotServiceTest.java
+++ b/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/UserSnapShotServiceTest.java
@@ -1,0 +1,104 @@
+package store.slackjudge.batch.infra.mongo.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import store.slackjudge.batch.infra.mongo.document.SnapShotId;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.mongo.dto.SaveSnapshot;
+import store.slackjudge.batch.infra.mongo.repository.UserSolvedSnapShotRepository;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserSnapShotServiceTest {
+    @InjectMocks
+    private UserSnapShotService service;
+
+    @Mock
+    private UserSolvedSnapShotRepository repository;
+
+
+    @Test
+    @DisplayName("service는 bojId와 snapAt로 이전 스냅샷을 repository에서 조회")
+    void findPreviousSnapshot() {
+        //given
+        String bojId="test";
+        LocalDateTime previousTime=LocalDateTime.now();
+        Long userId=2341442L;
+        int tier=123;
+        int solvedCount=3;
+        int rating=1251;
+
+        UserSolvedSnapShotDocument dummyDoc=makeDummyDocument(bojId,userId,tier,solvedCount,previousTime,rating);
+
+        when(repository.findByIdBojIdAndIdSnapShotAt(bojId,previousTime)).thenReturn(Optional.ofNullable(dummyDoc));
+
+        // when
+        Optional<UserSolvedSnapShotDocument> result=service.findPreviousSnapshot(bojId,previousTime);
+
+        //then
+        UserSolvedSnapShotDocument document=result.get();
+        verify(repository).findByIdBojIdAndIdSnapShotAt(bojId,previousTime);
+        assertThat(document).isEqualTo(dummyDoc);
+
+    }
+
+    @Test
+    @DisplayName("service는 SaveSnapshot dto 저장하고 저장된 document 반환")
+    void saveSnapshot() {
+        //given
+        String bojId="test";
+        LocalDateTime snapshotAt=LocalDateTime.now();
+        Long userId=2341442L;
+        int tier=123;
+        int solvedCount=3;
+        int rating=1234;
+
+
+        UserSolvedSnapShotDocument dummyDoc=makeDummyDocument(bojId,userId,tier,solvedCount,snapshotAt,rating);
+
+        SaveSnapshot request=new SaveSnapshot(
+                bojId,snapshotAt,new HashSet<>(),solvedCount,tier,userId,rating
+        );
+
+        when(repository.save(any(UserSolvedSnapShotDocument.class))).thenReturn(dummyDoc);
+
+        //when
+        UserSolvedSnapShotDocument result=service.saveSnapshot(request);
+
+        //then
+        verify(repository,times(1)).save(any());
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getTier()).isEqualTo(tier);
+        assertThat(result.getSolvedCount()).isEqualTo(solvedCount);
+        assertThat(result.getRating()).isEqualTo(rating);
+    }
+
+    private static UserSolvedSnapShotDocument makeDummyDocument(String bojId, Long userId, int tier, int solvedCount, LocalDateTime snapshotAt,int rating){
+        SnapShotId id=SnapShotId.of(bojId,snapshotAt);
+
+        return UserSolvedSnapShotDocument.builder()
+                .id(id)
+                .rating(rating)
+                .solvedCount(solvedCount)
+                .solvedProblemIds(new HashSet<>())
+                .tier(tier)
+                .userId(userId)
+                .build();
+    }
+
+}

--- a/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetectorTest.java
+++ b/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/detector/ProblemChangeDetectorTest.java
@@ -1,0 +1,127 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.solvedac.dto.ProblemInfoResponse;
+import store.slackjudge.batch.infra.solvedac.dto.ProblemSearchResponse;
+import store.slackjudge.batch.repository.ProblemJdbcRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProblemChangeDetectorTest {
+    @InjectMocks
+    private ProblemChangeDetector detector;
+
+    @Mock
+    private ProblemJdbcRepository repository;
+
+    @Test
+    @DisplayName("context의 1시간 전 스냅샷의 유저의 문제 풀이 개수와 " +
+                 "새로 조회한 유저의 문제 풀이 개수가 일치하지 않으면 true 반환"
+    )
+    void detect_Return_TRUE() {
+        //given
+        ProblemSearchResponse current = new ProblemSearchResponse(10, new ArrayList<>());
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .solvedCount(13)
+                .build();
+
+        DetectionContext<ProblemSearchResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "");
+
+        //when
+        Boolean result = detector.detect(context);
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("context의 1시간 전 스냅샷의 유저의 문제 풀이 개수와 " +
+                 "새로 조회한 유저의 문제 풀이 개수가 일치하면 false 반환"
+    )
+    void detect_Return_FALSE() {
+        //given
+        ProblemSearchResponse current = new ProblemSearchResponse(10, new ArrayList<>());
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .solvedCount(10)
+                .build();
+
+        DetectionContext<ProblemSearchResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "");
+
+        //when
+        Boolean result = detector.detect(context);
+
+        //then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("새로 푼 문제만 RDB에 update")
+    void update_New_Solved() {
+        //given
+        Set<Integer> previousSolvedProblems = Set.of(12, 45, 37, 4); //이전에 푼 문제 번호
+        List<ProblemInfoResponse> currentSolvedProblem = List.of(
+                new ProblemInfoResponse(12),
+                new ProblemInfoResponse(45),
+                new ProblemInfoResponse(37),
+                new ProblemInfoResponse(4),
+                new ProblemInfoResponse(23),
+                new ProblemInfoResponse(11),
+                new ProblemInfoResponse(5)
+        ); //새로 푼 문제 번호 -> 23,11,5
+
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .solvedProblemIds(previousSolvedProblems).build();
+        ProblemSearchResponse current = new ProblemSearchResponse(7, currentSolvedProblem);
+        DetectionContext<ProblemSearchResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "test");
+
+        //when
+        detector.update(context);
+
+        //then
+        verify(repository, times(3)).updateProblemSolved(any(), anyLong(), anyInt());
+        verify(repository).updateProblemSolved(context.snapshotAt(), context.userId(), 23);
+        verify(repository).updateProblemSolved(context.snapshotAt(), context.userId(), 11);
+        verify(repository).updateProblemSolved(context.snapshotAt(), context.userId(), 5);
+    }
+
+    @Test
+    @DisplayName("새로 푼 문제가 없으면 update 호출x")
+    void update_Nothing() {
+        //given
+        Set<Integer> previousSolvedProblems = Set.of(12, 45, 37, 4); //이전에 푼 문제 번호
+        List<ProblemInfoResponse> currentSolvedProblem = List.of(
+                new ProblemInfoResponse(12),
+                new ProblemInfoResponse(45),
+                new ProblemInfoResponse(37),
+                new ProblemInfoResponse(4)
+        );
+
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .solvedProblemIds(previousSolvedProblems).build();
+        ProblemSearchResponse current = new ProblemSearchResponse(7, currentSolvedProblem);
+        DetectionContext<ProblemSearchResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "test");
+
+        //when
+        detector.update(context);
+
+        //then
+         verify(repository, times(0)).updateProblemSolved(any(), anyLong(), anyInt());
+    }
+}

--- a/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/detector/TierChangeDetectorTest.java
+++ b/slackjudge/src/test/java/store/slackjudge/batch/infra/mongo/service/detector/TierChangeDetectorTest.java
@@ -1,0 +1,82 @@
+package store.slackjudge.batch.infra.mongo.service.detector;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import store.slackjudge.batch.infra.mongo.document.UserSolvedSnapShotDocument;
+import store.slackjudge.batch.infra.mongo.repository.UserSolvedSnapShotRepository;
+import store.slackjudge.batch.infra.solvedac.dto.UserInfoResponse;
+import store.slackjudge.batch.repository.UserJdbcRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TierChangeDetectorTest {
+    @InjectMocks
+    private TierChangeDetector detector;
+
+    @Mock
+    private UserJdbcRepository repository;
+
+    @DisplayName("context 1시간 전 스냅샷의 유저의 티어외 새로 조회한 유저의 티어가 일치하지 않으면 true 반환")
+    @Test
+    void detect_Return_TRUE() {
+        //given
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .tier(10)
+                .build();
+        UserInfoResponse current = new UserInfoResponse(10, "test", 12, 10);
+
+        DetectionContext<UserInfoResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "test");
+
+        //when
+        Boolean result = detector.detect(context);
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("context 1시간 전 스냅샷의 유저의 티어외 새로 조회한 유저의 티어가 일치하면 false 반환")
+    void update_Return_FALSE() {
+        //given
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .tier(10)
+                .build();
+        UserInfoResponse current = new UserInfoResponse(10, "test", 10, 10);
+
+        DetectionContext<UserInfoResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "test");
+
+        //when
+        Boolean result = detector.detect(context);
+
+        //then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("사용자 티어 변경 시 userJdbcRepository-updateUserTier 호출")
+    void update() {
+        //given
+        UserSolvedSnapShotDocument previous = UserSolvedSnapShotDocument.builder()
+                .tier(10)
+                .build();
+        UserInfoResponse current = new UserInfoResponse(10, "test", 30, 10);
+        DetectionContext<UserInfoResponse> context = new DetectionContext<>(current, previous, LocalDateTime.now(), 1L, "test");
+
+        //when
+        detector.update(context);
+
+        //then
+        verify(repository, times(1)).updateUsersTier("test",30);
+    }
+}

--- a/slackjudge/src/test/resources/application.yml
+++ b/slackjudge/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+    mongodb:
+      embedded:
+        version: 4.11.0


### PR DESCRIPTION
## 🍀 이슈 번호

- #14 

---

## ✅ 작업 사항

### 설계 구조

<img width="1882" height="674" alt="detector" src="https://github.com/user-attachments/assets/2982a24b-1583-472f-947d-5c89ef5316df" />

- **전략 패턴 구조 적용** 
   - `전략` : `SnapshotDetectStrategy`=>스냅샷에 대한 추상화 알고리즘
   - `전략 알고리즘 객체` : 
      - ProblemChangeDetector => 문제 개수 변경 감지 알고리즘 객체
      - TierChangeDetector => 사용자 티어 감지 알고리즘 객체
 - `OCP` 원칙을 준수하고자 했습니다.


### 시퀀스 다이어그램
<img width="1571" height="1578" alt="ZLLDJyD64BtxLymnKI5IFtf19EA32wYeY52fXqhLnbw8AsVNygv3kGKbLAXmW4FRj0eezAEe5OS8qfPAxH_2c__GzJgxsDaq8XB2ddrlPjwRqNgDSHJnk1KuAEQKnAq6ZXm7kPn6i86uswoxJUp50Ou0CJ0lJYXPlkk7YF0CjqCR4f4z5qu_OJZQyHhkFWufysNU4ubJqJHYGUi4XVKcvNKSjNqNfzWqn5v31KgT1ctihRif" src="https://github.com/user-attachments/assets/b08ef505-f6f1-43a5-ae23-3740dbb75074" />

[ 현재 PR까지 완료된 부분 ✅️ ]

1. 배치 시작
2. `UserJdbcRepository-findAllUserInfo()` 호출하여 모든 유저 정보 불러오기 ✅️
3. `UserSnapShotService-findPreviousSnapshot` 호출하여 모든 유저의 스냅샷 불러오기 ✅️
4. `SolvedAcUserInfoClient-call` 호출하여 모든 유저의 티어 정보 및 문제 수 가져오기 ✅️
5.  `4`에서 문제수가 변경된 유저들만 `SolvedAcProblemInfoClient-call `✅️  메서드 호출하여 새롭게 푼 문제 정보 가져오기 
6. `TierChangeDetector-detect` 사용자의 티어 정보 변경 감지 ✅️
    - **true** : `TierChangeDetector-update` 호출하여 RDB  유저 정보 업데이트
    - **false** :  pass
7. `ProblemChangeDetector-detect` 사용자의 새로 푼 문제 변경 감지 ✅️
   - **true** : `ProblemChangeDetector-update` 호출하여 RDB user-problem 테이블 업데이트
   - **false** : pass
8. 변경 점이 있는 user들만 `UserSnapShotService-saveSnapshot `메서드✅️ 실행 (변경 점이 없으면 이전 스냅샷 시간만 변경 후 저장)
9. 배치 완료

- 위 메서들을 다음 PR 때 Job에서 최종 조립하여 Batch 완료하도록 하겠습니다.

---

## ⌨ 기타
